### PR TITLE
hubot-slack package retrieve github

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "hubot-rules": "^0.1.0",
     "hubot-scripts": "^2.5.16",
     "hubot-shipit": "^0.2.0",
-    "hubot-slack": "^3.3.0",
+    "hubot-slack": "git://github.com/slackhq/hubot-slack.git",
     "hubot-youtube": "^0.1.2",
     "eastasianwidth": "^0.1.0"
   },


### PR DESCRIPTION
emitバグってて修正入った最新版が欲しかったのでnpm更新

ref: https://github.com/slackhq/hubot-slack/pull/162
# 確認方法

`$ npm install`して@robot.nameの部分とかfixされてるのを確認する

node_modules/hubot-slack/src/slack.coffee

``` coffee
268     if data.username && data.username != @robot.name
269       msg.as_user = false
270       msg.username = data.username
271       if data.icon_url?
272         msg.icon_url = data.icon_url
273       else if data.icon_emoji?
274         msg.icon_emoji = data.icon_emoji
275     else
276       msg.as_user = true
```
